### PR TITLE
Bug in the variable name

### DIFF
--- a/lib/zebra/ui.grid.js
+++ b/lib/zebra/ui.grid.js
@@ -1302,7 +1302,7 @@ pkg.Grid = Class(ui.Panel, ui.MouseListener, ui.KeyListener, Position.PositionMe
         },
 
         function setLineSize(s){
-            if(ns != this.lineSize){
+            if(s != this.lineSize){
                 this.lineSize = s;
                 this.vrp();
             }


### PR DESCRIPTION
Call to setLineSize will cause "Uncaught ReferenceError: ns is not defined"
